### PR TITLE
Bug/biolink class compare

### DIFF
--- a/biolink-model.mjs
+++ b/biolink-model.mjs
@@ -260,10 +260,10 @@ export function biolinkClassCmpFn(classA, classB) {
   let d2 = cmn.jsonGet(BIOLINK_CLASSES, classB, false);
   //console.log(`d1: ${d1.rank}; d2: ${d2.rank}`);
   if (!d1) {
-    console.error(`Expected a valid biolink class. Got: ${classA}`, 'biolink-model.mjs');
+    console.error(`Expected a valid biolink class. Got: ${classA}`);
     d1 = { rank: 0 };
   } else if (!d2) {
-    console.error(`Expected a valid biolink class. Got: ${classB}`, 'biolink-model.mjs');
+    console.error(`Expected a valid biolink class. Got: ${classB}`);
     d2 = { rank: 0 };
   }
 

--- a/biolink-model.mjs
+++ b/biolink-model.mjs
@@ -260,11 +260,13 @@ export function biolinkClassCmpFn(classA, classB) {
   let d2 = cmn.jsonGet(BIOLINK_CLASSES, classB, false);
   //console.log(`d1: ${d1.rank}; d2: ${d2.rank}`);
   if (!d1) {
-    throw InvalidClassError(class1);
+    console.error(`Expected a valid biolink class. Got: ${classA}`, 'biolink-model.mjs');
+    d1 = { rank: 0 };
   } else if (!d2) {
-    throw InvalidClassError(class2);
-  } else {
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description
-    return d2.rank - d1.rank;
+    console.error(`Expected a valid biolink class. Got: ${classB}`, 'biolink-model.mjs');
+    d2 = { rank: 0 };
   }
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description
+  return d2.rank - d1.rank;
 }

--- a/trapi.mjs
+++ b/trapi.mjs
@@ -509,7 +509,7 @@ function kedgePredicate(kedge)
 function kedgeToQualifiers(kedge)
 {
   const kedgeQualifiers = cmn.jsonGet(kedge, 'qualifiers', false);
-  if (!kedgeQualifiers)
+  if (!kedgeQualifiers || cmn.isArray(kedgeQualifiers))
   {
     return false;
   }
@@ -1093,7 +1093,6 @@ async function condensedSummariesToSummary(qid, condensedSummaries, annotationCl
   {
     function addInverseEdge(edges, edge)
     {
-      const edgePredicate = cmn.jsonGet(edge, 'predicate');
       const invertedPredicate = edgeToQualifiedPredicate(edge, true);
       const subject = cmn.jsonGet(edge, 'subject');
       const object = cmn.jsonGet(edge, 'object');


### PR DESCRIPTION
* Relaxed constraints on the biolink category sorting function to put invalid categories last instead of throw an error
* Fixed an edge case where edges are now returning with empty qualifier arrays