### PR TITLE
retain PKs when bookmarks are saved

### DIFF
--- a/ARSClient.mjs
+++ b/ARSClient.mjs
@@ -36,10 +36,11 @@ class ARSError extends Error {
 }
 
 class ARSClient {
-  constructor(origin, getPath, postPath, useARSMerging, completeCodes=[200,206], runningCodes=[202]) {
+  constructor(origin, getPath, postPath, retainPath, useARSMerging, completeCodes=[200,206], runningCodes=[202]) {
     this.origin = origin;
     this.getURL = `${origin}${getPath}`;
     this.postURL = `${origin}${postPath}`;
+    this.retainURL = `${origin}${retainPath}`;
     this.completeCodes = completeCodes;
     this.runningCodes = runningCodes;
     this.useARSMerging = useARSMerging;
@@ -47,6 +48,14 @@ class ARSClient {
 
   async postQuery(query) {
     return cmn.sendRecvJSON2(this.postURL, 'POST', {}, query)
+  }
+
+  async retainQuery(pkey) {
+    return cmn.sendRecvHTTP2(`${this.retainURL}/${pkey}`, 'POST', {},
+        null, 'application/json', {
+      encode: JSON.stringify,
+      decode: cmn.identity // TODO: change this when the ARS sends back valid JSON
+    });
   }
 
   async getQueryStatus(pkey, filters) {

--- a/StartServer.mjs
+++ b/StartServer.mjs
@@ -45,6 +45,7 @@ const TRANSLATOR_SERVICE = (function (config) {
     `${config.ars_endpoint.protocol}://${config.ars_endpoint.host}`,
     config.ars_endpoint.pull_uri,
     config.ars_endpoint.post_uri,
+    config.ars_endpoint.retain_uri,
     config.ars_endpoint.use_ars_merging);
   const annotationClient = new KGAnnotationClient(
     `https://${config.annotation_endpoint.host}`,

--- a/TranslatorService.mjs
+++ b/TranslatorService.mjs
@@ -55,6 +55,16 @@ class TranslatorService
     }
   }
 
+  async retainQuery(queryId) {
+    try {
+      const resp = await this.queryClient.retainQuery(queryId);
+      return resp;
+    } catch (err) {
+      console.log(err);
+      throw new QueryClientError(`Error retaining query for ${queryId}`, queryId, 'retain', err);
+    }
+  }
+
   async getQueryStatus(queryId, filters={})
   {
     try

--- a/configurations/ci.json
+++ b/configurations/ci.json
@@ -7,6 +7,7 @@
     "host": "ars.ci.transltr.io",
     "post_uri": "/ars/api/submit",
     "pull_uri": "/ars/api/messages",
+    "retain_uri": "/ars/api/retain",
     "protocol": "https",
     "use_ars_merging": true
   },

--- a/configurations/production.json
+++ b/configurations/production.json
@@ -7,6 +7,7 @@
     "host": "ars-prod.transltr.io",
     "post_uri": "/ars/api/submit",
     "pull_uri": "/ars/api/messages",
+    "retain_uri": "/ars/api/retain",
     "protocol": "https",
     "use_ars_merging": false
   },

--- a/configurations/test.json
+++ b/configurations/test.json
@@ -7,6 +7,7 @@
     "host": "ars.test.transltr.io",
     "post_uri": "/ars/api/submit",
     "pull_uri": "/ars/api/messages",
+    "retain_uri": "/ars/api/retain",
     "protocol": "https",
     "use_ars_merging": true
   },

--- a/routers/UserAPIController.mjs
+++ b/routers/UserAPIController.mjs
@@ -12,6 +12,7 @@ export { createUserController };
 
 function createUserController(config, services) {
   var router = express.Router();
+  var translatorService = services.translatorService;
   var userService = services.userService;
   var authService = services.authService;
 
@@ -79,6 +80,19 @@ function createUserController(config, services) {
   router.post('/me/saves', async function(req, res, next) {
     try {
       let data = {...req.body};
+      // TODO: generalize saving object behavior when we start saving more types
+      if (data.save_type === 'bookmark') {
+        const pk = data.ars_pkey
+        if (!pk) {
+          const error = 'No PK in save for result';
+          wutil.logInternalServerError(req, error);
+          return wutil.sendError(res, 400, error);
+        } else {
+          console.log(`Retaining ${pk}`);
+          await translatorService.retainQuery(pk);
+        }
+      }
+
       data.user_id = req.user.id;
       let saveData = new UserSavedData(data);
       let result = await userService.saveUserData(saveData);


### PR DESCRIPTION
If the ARS fails to retain the PK we treat that as an error and avoid writing it to the DB. The reason is because we do not want to get into a situation where the user's bookmarked PKs suddenly disappear.