### PR TITLE
fix bug with merging node tags into paths

### DIFF
--- a/lib/trapi.mjs
+++ b/lib/trapi.mjs
@@ -808,6 +808,11 @@ function makeTagDescription(name, description = '') {
   };
 }
 
+function isResultTag(tag) {
+  return tag.startsWith('role:') ||
+         tag.startsWith('fda:');
+}
+
 function determineAnswerTag(type, answerTags, queryType) {
   function isDrug(type, fdaLevel) {
     return fdaLevel === 4 || type === 'Drug';
@@ -1895,14 +1900,16 @@ async function summaryFragmentsToSummary(qid, condensedSummaries, kgraph, queryT
         if (isNodeIndex(i)) {
           const node = nodes[path.subgraph[i]];
           if (node !== undefined) { // Remove me when result graphs are fixed
-            // Take all node tags
-            Object.keys(node.tags).forEach((k) => { tags[k] = node.tags[k]; });
+            // Merge all global node tags into the path
+            Object.keys(node.tags).filter((tag) => !isResultTag(tag)).forEach((k) => { tags[k] = node.tags[k]; });
 
             // Generate tags based on the node category
             const type = cmn.isArrayEmpty(node.types) ?
                          'Named Thing' :
                           bl.sanitizeBiolinkItem(node.types[0]);
             if (i === 0) {
+              // Merge result level node tags
+              Object.keys(node.tags).filter(isResultTag).forEach((k) => { tags[k] = node.tags[k]; });
               const [answerTag, answerDescription] = determineAnswerTag(type, node.tags, queryType);
               if (answerTag) {
                 tags[answerTag] = makeTagDescription(answerDescription);


### PR DESCRIPTION
This issue occured because some facets only apply to result nodes on a path and some facets apply to all nodes on a path. In the case where an internal node of a path was also a result node the path would incorrectly pick up result level tags from an internal node.