### PR TITLE
Add a consistent and globally available logger

### DIFF
--- a/HTTPServer.mjs
+++ b/HTTPServer.mjs
@@ -1,5 +1,6 @@
 'use strict'
 
+import { logger } from './lib/logger.mjs';
 import { default as path } from 'node:path';
 import { default as url } from 'node:url';
 import { default as express } from 'express';
@@ -34,7 +35,6 @@ export function startServer(config, services) {
   const sessionController = new SessionController(config, authService);
   const API_PATH_PREFIX = '/api/v1';
   const SITE_PATH_PREFIX = '';
-  const logger = pino();
   app.use(pinoHttp({logger: logger}));
   app.use(express.json({ limit: config.json_payload_limit }));
   app.use(cookieParser());
@@ -124,7 +124,7 @@ export function startServer(config, services) {
     if (['/main', '/demo'].includes(req.originalUrl)) {
       res.redirect(308, '/');
     }
-    console.log(`redirection: ${req.originalUrl} -> ${req.originalUrl.replace(/^\/(main|demo)/, '')}`);
+    logger.info(`redirection: ${req.originalUrl} -> ${req.originalUrl.replace(/^\/(main|demo)/, '')}`);
     res.redirect(308, req.originalUrl.replace(/^\/(main|demo)/, ''));
   });
 
@@ -134,5 +134,5 @@ export function startServer(config, services) {
   });
 
   app.listen(8386);
-  console.log("Der Anfang ist das Ende und das Ende ist der Anfang");
+  logger.info("Der Anfang ist das Ende und das Ende ist der Anfang");
 }

--- a/HTTPServer.mjs
+++ b/HTTPServer.mjs
@@ -3,6 +3,7 @@
 import { default as path } from 'node:path';
 import { default as url } from 'node:url';
 import { default as express } from 'express';
+import { default as pino } from 'pino';
 import { default as pinoHttp } from 'pino-http';
 import { default as cookieParser } from 'cookie-parser';
 
@@ -33,8 +34,8 @@ export function startServer(config, services) {
   const sessionController = new SessionController(config, authService);
   const API_PATH_PREFIX = '/api/v1';
   const SITE_PATH_PREFIX = '';
-
-  app.use(pinoHttp());
+  const logger = pino();
+  app.use(pinoHttp({logger: logger}));
   app.use(express.json({ limit: config.json_payload_limit }));
   app.use(cookieParser());
 

--- a/StartServer.mjs
+++ b/StartServer.mjs
@@ -1,4 +1,5 @@
 'use strict'
+import { logger } from './lib/logger.mjs';
 
 import { bootstrapConfig } from './lib/config.mjs';
 
@@ -83,9 +84,7 @@ const USER_SERVICE = (function (config) {
   );
 })(SERVER_CONFIG);
 
-let log_config = { ...SERVER_CONFIG};
-log_config.secrets = '[REDACTED]'
-console.log(log_config);
+logger.info(SERVER_CONFIG, "Server configuration");
 
 httpserver.startServer(SERVER_CONFIG, {
   translatorService: TRANSLATOR_SERVICE,

--- a/controllers/LoginController.mjs
+++ b/controllers/LoginController.mjs
@@ -93,13 +93,13 @@ class LoginController {
     // Second, kill the session internally
     let session = await this.authService.retrieveSessionByToken(cookieToken);
     if (!session) {
-      console.error(`%% %% %% no session found for ${cookieToken} when logging out`);
+      req.log.error(`%% %% %% no session found for ${cookieToken} when logging out`);
     }
     session = await this.authService.expireSessionByToken(cookieToken);
     if (!session) {
-      console.error(`%% %% %% error expiring session for ${cookieToken} when logging out`);
+      req.log.error(`%% %% %% error expiring session for ${cookieToken} when logging out`);
     }
-    console.log(`Logout successful, redirecting to /`);
+    req.log.info(`Logout successful, redirecting to /`);
     return res.redirect(302, `/`);
   }
 }

--- a/controllers/UserAPIController.mjs
+++ b/controllers/UserAPIController.mjs
@@ -89,7 +89,7 @@ class UserAPIController {
           wutil.logInternalServerError(req, error);
           return wutil.sendError(res, 400, error);
         } else {
-          console.log(`Retaining ${pk}`);
+          req.log.info(`Retaining ${pk}`);
           await this.translatorService.retainQuery(pk);
         }
       }

--- a/lib/ARSClient.mjs
+++ b/lib/ARSClient.mjs
@@ -1,5 +1,6 @@
 'use strict'
 
+import { logger } from "./logger.mjs";
 import * as cmn from "./common.mjs";
 export { ARSClient };
 
@@ -212,7 +213,7 @@ class ARSClient {
         try {
           errored.push(extractFields(c));
         } catch (err) {
-          console.error(`Error extracting fields from ARS error response: '${err}'`);
+          logger.error(`Error extracting fields from ARS error response: '${err}'`);
           errored.push(c);
         }
       }
@@ -231,7 +232,7 @@ class ARSClient {
       let toFetch = agents.map(e => completed[e].uuid);
       let start = new Date();
       const promises = toFetch.map(async (e) => {
-        console.log(`kicking off fetch for ${e}`);
+        logger.info(`kicking off fetch for ${e}`);
         return this._fetchMessage(e);
       });
       let finalCompleted = [];
@@ -249,14 +250,14 @@ class ARSClient {
 
             elem.meta = item.value[0];
             finalCompleted.push(elem);
-            console.log(`settled ${agent}`);
+            logger.info(`settled ${agent}`);
           } else {
             //
-            console.error('Unexpected case of being unable to fetch a result for an agent that reported code=200');
+            logger.error('Unexpected case of being unable to fetch a result for an agent that reported code=200');
             errored.push(item.value); // No idea what might be in this object
           }
         });
-        console.log('done settling promises');
+        logger.info('done settling promises');
         retval = {
           pk: pkey,
           completed: finalCompleted,
@@ -286,6 +287,7 @@ class ARSClient {
       mergedVersionList.reverse(); // First element should be the most recent
       const statusPromises = mergedVersionList.map((mergedEntry) => {
         const [uuid, agent] = mergedEntry;
+
         return this._fetchMessage(uuid, true);
       });
 

--- a/lib/ARSClient.mjs
+++ b/lib/ARSClient.mjs
@@ -291,7 +291,6 @@ class ARSClient {
 
       await Promise.allSettled(statusPromises).then((promises) => {
         let i = 0;
-        let foundMostRecentDone = false;
         for (const promise of promises) {
           if (promise.status !== 'fulfilled') continue;
 
@@ -304,8 +303,8 @@ class ARSClient {
 
           // We have to inject the status codes because we expect them but the ARS does not
           // provide them
-          if (foundMostRecentDone || message.status === 'Done' ||
-              message.status === 'Error' && message.code === 444) {
+          if (message.status === 'Done' ||
+              (message.status === 'Error' && message.code === 444)) {
             status.code = 200;
             completed.push(status);
           } else if (message.status === 'Running') {

--- a/lib/SocialSignOn.mjs
+++ b/lib/SocialSignOn.mjs
@@ -1,5 +1,5 @@
 'use strict';
-
+import { logger } from './logger.mjs';
 import jwt from 'jsonwebtoken';
 import { SendRecvJSON, SendRecvFormEncoded } from '../lib/common.mjs';
 export { handleSSORedirect };
@@ -29,7 +29,7 @@ async function handleSSORedirect(provider, authcode, config, codeVerifier=null) 
         token_uri: config.auth.social_providers.una.token_uri
       });
       break;
-    default: console.error(`Cannot handle provider: ${provider}`); break;
+    default: logger.error(`Cannot handle provider: ${provider}`); break;
   }
   return retval;
 }
@@ -130,7 +130,7 @@ function parseJWT(token, secret=null) {
       const decoded = jwt.verify(token, secret);
       verified = true;
     } catch (err) {
-      console.error(err);
+      logger.error(err);
     }
   }
 

--- a/lib/biolink-model.mjs
+++ b/lib/biolink-model.mjs
@@ -1,5 +1,6 @@
 'use strict'
 
+import { logger } from './logger.mjs';
 import * as cmn from './common.mjs';
 
 let BIOLINK_PREDICATES = null;
@@ -305,12 +306,12 @@ function makeBlClasses(classes) {
 export function biolinkClassCmpFn(classA, classB) {
   let d1 = cmn.jsonGet(BIOLINK_CLASSES, classA, false);
   let d2 = cmn.jsonGet(BIOLINK_CLASSES, classB, false);
-  //console.log(`d1: ${d1.rank}; d2: ${d2.rank}`);
+  //logger.info(`d1: ${d1.rank}; d2: ${d2.rank}`);
   if (!d1) {
-    console.error(`Expected a valid biolink class. Got: ${classA}`);
+    logger.error(`Expected a valid biolink class. Got: ${classA}`);
     d1 = { rank: 0 };
   } else if (!d2) {
-    console.error(`Expected a valid biolink class. Got: ${classB}`);
+    logger.error(`Expected a valid biolink class. Got: ${classB}`);
     d2 = { rank: 0 };
   }
 

--- a/lib/evidence.mjs
+++ b/lib/evidence.mjs
@@ -1,9 +1,13 @@
+'use strict';
+
+import { logger } from "./logger.mjs";
+
 export function isValidId(id)
 {
   const [url, type] = idToTypeAndUrl(id);
   const isValid = !!url && !!type;
   if (!isValid) {
-    console.error(`Invalid id: ${id}`);
+    logger.error(`Invalid id: ${id}`);
   }
 
   return isValid;

--- a/lib/logger.mjs
+++ b/lib/logger.mjs
@@ -1,0 +1,8 @@
+'use strict';
+
+import { default as pino } from 'pino';
+
+export const logger = pino({
+  level: 'info',
+  redact: ['secrets'] // For the config object
+});

--- a/lib/postgres_preamble.mjs
+++ b/lib/postgres_preamble.mjs
@@ -3,6 +3,7 @@
 // This worked after a bit of trial and error.
 import pg from 'pg';
 
+import { logger } from './logger.mjs';
 export { pg, pgExec, pgExecTrans };
 
 /* Technically unsafe due to integer precision in node but probably fine in reality.
@@ -18,7 +19,7 @@ async function pgExec(pool, sql, sqlParams=[]) {
     const res = await client.query(sql, sqlParams);
     return res;
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     throw err;
   } finally {
     if (client) {
@@ -36,7 +37,7 @@ async function pgExecTrans(pool, fun, ...args) {
     await client.query('COMMIT');
     return res;
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     await client.query('ROLLBACK');
   } finally {
     if (client) {

--- a/lib/trapi.mjs
+++ b/lib/trapi.mjs
@@ -5,6 +5,7 @@ import * as cmn from './common.mjs';
 import * as ev from './evidence.mjs';
 import * as bl from './biolink-model.mjs';
 import * as bta from './biothings-annotation.mjs';
+import { logger } from './logger.mjs';
 
 const subjectKey = 'sn';
 const objectKey = 'on';
@@ -1374,7 +1375,7 @@ function creativeAnswersToSummaryFragments(answers, nodeRules, edgeRules, maxHop
           {},
           {});
       } catch (err) {
-        console.error(err);
+        logger.error(err);
         if (err instanceof EdgeBindingNotFoundError) {
           return errorSummaryFragment(agent, e.message);
         }
@@ -1773,7 +1774,7 @@ async function summaryFragmentsToSummary(qid, condensedSummaries, kgraph, queryT
 
         aras = [...aras];
         const errorString = "No root paths found";
-        console.error(`${aras.join(', ')}: ${errorString}`)
+        logger.error(`${aras.join(', ')}: ${errorString}`)
         for (const ara of aras) {
           const araErrors = cmn.jsonSetDefaultAndGet(errors, ara, []);
           araErrors.push(errorString);
@@ -1885,7 +1886,7 @@ async function summaryFragmentsToSummary(qid, condensedSummaries, kgraph, queryT
     // Remove any edges that have a missing subject, object, predicate, or provenance
     const edgeErrorReasons = reasonsForEdgeErrors(edge);
     if (edgeErrorReasons.length !== 0) {
-      console.error(`Found invalid edge ${ek}. Reasons: ${JSON.stringify(edgeErrorReasons)}`);
+      logger.error(`Found invalid edge ${ek}. Reasons: ${JSON.stringify(edgeErrorReasons)}`);
       updateErrorsFromEdge(edge, errors, edgeErrorReasons);
       delete edges[ek];
       return;
@@ -2067,7 +2068,7 @@ async function summaryFragmentsToSummary(qid, condensedSummaries, kgraph, queryT
     extendSummaryErrors(errors, annotationContext.errors);
   }
   catch (err) {
-    console.error(err);
+    logger.error(err);
   }
   finally {
     // Node post-processing

--- a/lib/webutils.mjs
+++ b/lib/webutils.mjs
@@ -3,7 +3,7 @@ import { logger } from "./logger.mjs";
 export { sendError, sendInternalServerError, logInternalServerError, setSessionCookie };
 
 function sendError(res, errorCode, trace) {
-  console.error(trace);
+  logger.error(trace);
   const response = {
     'status': 'error',
     'data': trace

--- a/lib/webutils.mjs
+++ b/lib/webutils.mjs
@@ -1,5 +1,5 @@
 'use strict';
-
+import { logger } from "./logger.mjs";
 export { sendError, sendInternalServerError, logInternalServerError, setSessionCookie };
 
 function sendError(res, errorCode, trace) {
@@ -20,7 +20,7 @@ function logInternalServerError(req, err) {
 }
 
 function setSessionCookie(res, cookieConfig, cookieVal, cookiePath, maxAgeSec) {
-  console.log(`_+_+_+_+_ set session cookie: [${cookieConfig.name}/${maxAgeSec}]: ${cookieVal}`);
+  logger.debug(`set session cookie: [${cookieConfig.name}/${maxAgeSec}]: ${cookieVal}`);
   res.cookie(cookieConfig.name, cookieVal, {
     maxAge: maxAgeSec * 1000,
     path: cookiePath,

--- a/services/AuthService.mjs
+++ b/services/AuthService.mjs
@@ -1,5 +1,6 @@
 'use strict';
 
+import { logger } from '../lib/logger.mjs';
 import { Session } from '../models/Session.mjs';
 import { User } from '../models/User.mjs';
 import * as sso from '../lib/SocialSignOn.mjs';
@@ -184,7 +185,7 @@ class AuthService {
       }));
       return res;
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return null;
     }
   }
@@ -195,7 +196,7 @@ class AuthService {
        res = this.sessionStore.createNewSession(new Session());
        return res;
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return res;
     }
   }
@@ -210,7 +211,7 @@ class AuthService {
       }));
       return res;
    } catch (err) {
-     console.error(err);
+     logger.error(err);
      return res;
    }
 
@@ -222,7 +223,7 @@ class AuthService {
       res = this.sessionStore.retrieveSessionByToken(token);
       return res;
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return res;
     }
   }
@@ -232,7 +233,7 @@ class AuthService {
       sessionData.updateSessionTime();
       return this.sessionStore.updateSession(sessionData);
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }
@@ -243,7 +244,7 @@ class AuthService {
       sessionData.updateSessionTime()
       return this.sessionStore.updateSession(sessionData);
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }
@@ -297,40 +298,40 @@ class AuthService {
   async validateAuthSessionToken(token) {
     let tokenRefreshed = false;
     if (!token || !this.isTokenSyntacticallyValid(token)) {
-      console.error(`%% %% %% no cookie found`);
+      logger.error(`%% %% %% no cookie found`);
       throw new CookieNotFoundError();
     }
-    console.error(`%% %% %% we get cookie: ${token}`);
+    logger.error(`%% %% %% we get cookie: ${token}`);
 
     let session = await this.retrieveSessionByToken(token);
 
     if (!session) {
-      console.error(`%% %% %% no session found for ${token}`);
+      logger.error(`%% %% %% no session found for ${token}`);
       throw new SessionNotFoundError(cookie);
     }
-    console.error(`%% %% %% we get session: ${JSON.stringify(session)}`);
+    logger.error(`%% %% %% we get session: ${JSON.stringify(session)}`);
 
     if (!session.user_id || session.force_kill) {
-      console.error(`%% %% %% no user found for ${JSON.stringify(session)} or else force killed`);
+      logger.error(`%% %% %% no user found for ${JSON.stringify(session)} or else force killed`);
       throw new SessionNotUsableError(token, session.id);
     }
     const user = await this.getUserById(session.user_id);
     if (!user) {
-      console.error(`%% %% %% no user found`);
+      logger.error(`%% %% %% no user found`);
       throw new NoUserForSessionError(token, session.id);
     } else if (user.deleted) {
-      console.error(`%% %% %% User deleted`);
+      logger.error(`%% %% %% User deleted`);
       throw new UserDeletedError(user.id);
     } else if (this.isSessionExpired(session)) {
-      console.error(`%% %% %% Session expired: ${JSON.stringify(session)}`);
+      logger.error(`%% %% %% Session expired: ${JSON.stringify(session)}`);
       throw new SessionExpiredError(token, session.id);
     } else if (this.isTokenExpired(session)) {
-      console.error(`%% %% %% Token expired, refreshing: ${JSON.stringify(session)}`);
+      logger.error(`%% %% %% Token expired, refreshing: ${JSON.stringify(session)}`);
       session = await this.refreshSessionToken(session);
       tokenRefreshed = true;
     } else {
       // Valid session - update time
-      console.error(`%% %% %% session good, udpating time: ${JSON.stringify(session)}`);
+      logger.error(`%% %% %% session good, udpating time: ${JSON.stringify(session)}`);
       session = await this.updateSessionTime(session);
     }
 

--- a/services/TranslatorService.mjs
+++ b/services/TranslatorService.mjs
@@ -1,5 +1,5 @@
 'use strict';
-
+import { logger } from '../lib/logger.mjs';
 import * as arsmsg from '../lib/ARSMessages.mjs';
 import * as trapi from '../lib/trapi.mjs';
 
@@ -59,7 +59,7 @@ class TranslatorService
       const resp = await this.queryClient.retainQuery(queryId);
       return resp;
     } catch (err) {
-      console.log(err);
+      logger.log(err);
       throw new QueryClientError(`Error retaining query for ${queryId}`, queryId, 'retain', err);
     }
   }
@@ -86,7 +86,7 @@ class TranslatorService
     }
     catch (err)
     {
-      console.error(`Error retrieving results for ${queryId}: '${err}'`);
+      logger.error(`Error retrieving results for ${queryId}: '${err}'`);
       throw new QueryClientError(`Error retrieving results for ${queryId}`, queryId, 'result', err);
     }
   }

--- a/stores/UserPreferenceStorePostgres.mjs
+++ b/stores/UserPreferenceStorePostgres.mjs
@@ -1,5 +1,6 @@
 'use strict';
 
+import { logger } from '../lib/logger.mjs';
 import { pg, pgExec, pgExecTrans } from '../lib/postgres_preamble.mjs';
 import { UserPreference } from '../models/UserPreference.mjs'; // path to the UserPreference class
 
@@ -34,7 +35,7 @@ class UserPreferenceStorePostgres {
         `;
         const checkRes = await client.query(checkSql, [userPreference.pref_name]);
         if (checkRes.rows.length === 0) {
-          console.error(`Preference "${userPreference.pref_name}" does not exist in preferences table`);
+          logger.error(`Preference "${userPreference.pref_name}" does not exist in preferences table`);
           continue;
         }
         const prefId = checkRes.rows[0].id;


### PR DESCRIPTION
This change adds a pino logger into the backend and uses it consistently in all sources that are part of the web application. Utility files are not updated as a part of this change; that is left up to the individual author for now.

Making our log lines uniform sets us up well for ingestion into log aggregators and analyzers. 

I've hardcoded the minimal log level as 'info' for now, which means only log messages of info and _higher_ priority will be logged. This log level should at some point be moved into config but that needs more careful thought; and harcoding as 'info' should not have any negative consequences for now (if anything, it's a blunt safeguard). 

Thanks to what appears to be good module design, the same logger object doubles up as the app middleware logger as well--sweet!