### PR TITLE
add summarization flag to config endpoint

### DIFF
--- a/configurations/frontend/ci.json
+++ b/configurations/frontend/ci.json
@@ -337,5 +337,6 @@
        "id": "PUBCHEM.COMPOUND:2162"
      }
   ],
-  "include_pathfinder": true
+  "include_pathfinder": true,
+  "include_summarization": true
 }

--- a/configurations/frontend/production.json
+++ b/configurations/frontend/production.json
@@ -328,5 +328,6 @@
         "id": "PUBCHEM.COMPOUND:2162"
     }
   ],
-  "include_pathfinder": false
+  "include_pathfinder": false,
+  "include_summarization": false
 }

--- a/configurations/frontend/test.json
+++ b/configurations/frontend/test.json
@@ -337,5 +337,6 @@
       "id": "PUBCHEM.COMPOUND:2162"
     }
   ],
-  "include_pathfinder": false
+  "include_pathfinder": false,
+  "include_summarization": false
 }

--- a/controllers/ConfigAPIController.mjs
+++ b/controllers/ConfigAPIController.mjs
@@ -13,7 +13,8 @@ class ConfigAPIController {
       cached_queries: this.config.frontend.cached_queries.filter(e => e.allow_outbound),
       name_resolver: this.config.frontend.name_resolver.endpoint,
       social_providers: this.config.auth.social_providers,
-      include_pathfinder: this.config.frontend.include_pathfinder
+      include_pathfinder: this.config.frontend.include_pathfinder,
+      include_summarization: this.config.frontend.include_summarization
     });
   }
 }


### PR DESCRIPTION
Adds an `include_summarization` flag to the config endpoint which the FE can use to determine whether LLM summarization should be activated in a given environment. 