### PR TITLE
Add dailymed publication processing

### DIFF
--- a/lib/evidence.mjs
+++ b/lib/evidence.mjs
@@ -4,10 +4,10 @@ import { logger } from "./logger.mjs";
 import * as cmn from "#lib/common.mjs";
 
 export function is_valid_id(id) {
-  const [url, type] = id_to_type_and_url(id);
+  const [type, url] = id_to_type_and_url(id);
   const is_valid = !(cmn.is_missing(url) || cmn.is_missing(type));
   if (!is_valid) {
-    logger.error(`Invalid id: ${id}`);
+    logger.debug(`Invalid id: ${id}`);
   }
   return is_valid;
 }
@@ -63,6 +63,9 @@ export function id_to_type_and_url(id) {
     return ["CHEMBL", _chembl_to_url(id)];
   } else if (_has_tag(id, "ISBN")) {
     return ["ISBN", _isbn_to_url(id)];
+  } else if (_has_tag(id, "dailymed")) {
+    const dailymed_url = _dailymed_to_url(id);
+    return dailymed_url ? ["dailymed", dailymed_url] : [null, null];
   } else if (_is_url(id)) {
     return ["other", id];
   } else {
@@ -106,6 +109,13 @@ export function id_to_type_and_url(id) {
   }
   function _chembl_to_url(id) {
     return _tagged_id_to_url(id, "https://www.ebi.ac.uk/chembl/explore/document");
+  }
+  function _dailymed_to_url(id) {
+    const stripped_id = _strip_tag(id);
+    if (!!stripped_id) {
+      return `https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=${stripped_id}`;
+    }
+    return false;
   }
   function _has_tag(id, tag) {
     return id.startsWith(tag);

--- a/lib/summarization/property-rules.mjs
+++ b/lib/summarization/property-rules.mjs
@@ -22,7 +22,7 @@ function make_rule_group_publications_by_knowledge_level() {
       const publications = [];
       for (let i = 0; i < pids.length; i++) {
         const pid = pids[i];
-        if (ev.is_go_ref(pid)) {
+        if (!ev.is_valid_id(pid) || ev.is_go_ref(pid)) {
           if (logger.isLevelEnabled("debug")) {
             logger.debug(`Filtering publication: ${pid}`);
           }

--- a/test/data/evidence.mjs
+++ b/test/data/evidence.mjs
@@ -1,0 +1,34 @@
+export { suite }
+
+import * as test from "#test/lib/common.mjs";
+
+const suite = {
+  tests: {
+    id_to_type_and_url: _test_id_to_type_and_url()
+  },
+  skip: {
+    is_valid_id: true,
+    is_go_ref: true,
+    sanitize: true,
+    is_clinical_trial: true,
+    is_publication: true,
+    is_ontological: true
+  }
+};
+
+function _test_id_to_type_and_url() {
+  return test.make_function_test({
+    "dailymed_setid": {
+      "args": ["dailymed:e1ada3ec-c2c0-4f43-9b4b-1234567890ab"],
+      "expected": ["dailymed", "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=e1ada3ec-c2c0-4f43-9b4b-1234567890ab"]
+    },
+    "dailymed_missing_setid": {
+      "args": ["dailymed:"],
+      "expected": [null, null]
+    },
+    "dailymed_prefix_without_colon": {
+      "args": ["dailymed"],
+      "expected": [null, null]
+    }
+  });
+}

--- a/test/evidence.mjs
+++ b/test/evidence.mjs
@@ -1,0 +1,10 @@
+export { test_evidence }
+
+import * as test from "#test/lib/common.mjs";
+
+async function test_evidence() {
+  await test.module_test({
+    "module_path": "#lib/evidence.mjs",
+    "suite_path": "#test/data/evidence.mjs"
+  });
+}

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -8,6 +8,7 @@ import {test_summary_node} from "#test/summarization/SummaryNode.mjs";
 import {test_summary_edge} from "#test/summarization/SummaryEdge.mjs";
 import {test_biolink_model} from "#test/biolink-model.mjs";
 import {test_biothings_annotation} from "#test/biothings-annotation.mjs";
+import {test_evidence} from "#test/evidence.mjs";
 
 logger.level = "silent";
 await test_trapi_core();
@@ -19,3 +20,4 @@ await test_summary_node();
 await test_summary_edge();
 await test_biolink_model();
 await test_biothings_annotation();
+await test_evidence();


### PR DESCRIPTION
* Add processing for publications in form "dailymed:<uuid>" that is classifed as misc evidence.
* Add unit test specifically for dailymed publication processing
* Fix a code clarity error in evidence.mjs:is_valid_id where destructing was in the wrong order. This change does not affect the usage of the function.